### PR TITLE
renaming get_puppet_facts to puppet_facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ f = facter.Facter(facter_path="/usr/local/bin/facter")
 f = facter.Facter(external_dir="/etc/puppetlabs/facter/facts.d")
 
 # Include Puppet facts
-f = facter.Facter(get_puppet_facts=True)
+f = facter.Facter(puppet_facts=True)
 
 # Disable caching
 f = facter.Facter(cache_enabled=False)

--- a/facter/__init__.py
+++ b/facter/__init__.py
@@ -55,7 +55,7 @@ class Facter:
         facter_path: str = "facter",
         external_dir: Optional[str] = None,
         cache_enabled: bool = True,
-        get_puppet_facts: bool = False,
+        puppet_facts: bool = False,
         legacy_facts: bool = False,
         # Deprecated - kept for backward compatibility
         use_yaml: Optional[bool] = None,
@@ -63,7 +63,7 @@ class Facter:
         self.facter_path = facter_path
         self.external_dir = external_dir
         self.cache_enabled = cache_enabled
-        self._get_puppet_facts = get_puppet_facts
+        self.puppet_facts = puppet_facts
         self.legacy_facts = legacy_facts
         self._cache: Optional[Dict[str, Any]] = None
 
@@ -97,7 +97,7 @@ class Facter:
         base_args = [self.facter_path]
 
         # Add common arguments
-        if self._get_puppet_facts:
+        if self.puppet_facts:
             base_args.append("--puppet")
         if self.external_dir is not None:
             base_args.extend(["--external-dir", self.external_dir])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -130,7 +130,7 @@ class TestFacterIntegration:
         """Test puppet facts option."""
         # This might fail on systems without Puppet installed
         try:
-            f = Facter(get_puppet_facts=True)
+            f = Facter(puppet_facts=True)
             facts = f.all
             assert isinstance(facts, dict)
         except RuntimeError as e:


### PR DESCRIPTION
`puppet_facts` is more similar to other options, renaming